### PR TITLE
Fix IE11 form initialising data a frame later

### DIFF
--- a/form-on-change.js
+++ b/form-on-change.js
@@ -5,7 +5,9 @@ angular.module('chenop.form-on-change', [])
             link: function(scope, element, attrs){
                 var callBack = $parse(attrs.formOnChange);
                 element.on("change", function(){
-                    callBack(scope);
+                    setTimeout(function() {
+                        callBack(scope);
+                    }, 0);
                 });
             }
         }


### PR DESCRIPTION
I ran into a bug in IE11 where the form data was not yet updated while the callback function was being called, triggering the callback a frame later (on a setTimeout) fixed the issue.